### PR TITLE
better display multi cloud/region deployments in cli

### DIFF
--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -162,7 +162,6 @@ pub async fn info() {
 
   let column = Column {
     header: "App Id".into(),
-    align: Align::Left,
     ..Column::default()
   };
   clusters.columns.insert(0, column);

--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -10,7 +10,7 @@ use std::fs::{File, read};
 use std::io::BufReader;
 use std::path::Path;
 
-use ascii_table::{AsciiTable, Column, Align};
+use ascii_table::{AsciiTable, Column};
 use base64;
 
 const URL: &str = if cfg!(debug_assertions) {

--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -160,29 +160,35 @@ pub async fn info() {
   let mut clusters = AsciiTable::default();
   clusters.max_width = 140;
 
-  let mut column = Column::default();
-  column.header = "App Id".into();
-  column.align = Align::Left;
+  let column = Column {
+    header: "App Id".into(),
+    align: Align::Left,
+    ..Column::default()
+  };
   clusters.columns.insert(0, column);
 
-  let mut column = Column::default();
-  column.header = "Url".into();
-  column.align = Align::Left;
+  let column = Column {
+    header: "Url".into(),
+    ..Column::default()
+  };
   clusters.columns.insert(1, column);
 
-  let mut column = Column::default();
-  column.header = "Deploy Config".into();
-  column.align = Align::Left;
+  let column = Column {
+    header: "Deploy Config".into(),
+    ..Column::default()
+  };
   clusters.columns.insert(2, column);
 
-  let mut column = Column::default();
-  column.header = "Size".into();
-  column.align = Align::Left;
+  let column = Column {
+    header: "Size".into(),
+    ..Column::default()
+  };
   clusters.columns.insert(3, column);
 
-  let mut column = Column::default();
-  column.header = "Version".into();
-  column.align = Align::Left;
+  let column = Column {
+    header: "Version".into(),
+    ..Column::default()
+  };
   clusters.columns.insert(4, column);
 
   let mut deploy_names = Vec::new();
@@ -200,19 +206,22 @@ pub async fn info() {
   deploy.max_width = 140;
 
   for deploy_name in deploy_names {
-    let mut column = Column::default();
-    column.header = "Deploy Config".into();
-    column.align = Align::Left;
+    let column = Column {
+      header: "Deploy Config".into(),
+      ..Column::default()
+    };
     deploy.columns.insert(0, column);
 
-    let mut column = Column::default();
-    column.header = "Cloud Provider".into();
-    column.align = Align::Left;
+    let column = Column {
+      header: "Cloud Provider".into(),
+      ..Column::default()
+    };
     deploy.columns.insert(1, column);
 
-    let mut column = Column::default();
-    column.header = "Region".into();
-    column.align = Align::Left;
+    let column = Column {
+      header: "Region".into(),
+      ..Column::default()
+    };
     deploy.columns.insert(2, column);
 
     let cloud_configs = deploy_configs.get(&deploy_name.to_string()).unwrap();


### PR DESCRIPTION
```
Status of all apps deployed using the cloud credentials in ~/.anycloud/deploy.json

┌─────────────────┬─────────────────────────────────────────┬───────────────┬──────┬─────────────────┐
│ App Id          │ Url                                     │ Deploy Config │ Size │ Version         │
├─────────────────┼─────────────────────────────────────────┼───────────────┼──────┼─────────────────┤
│ red-partridge-3 │ https://red-partridge-3.anycloudapp.com │ aws-us        │ 2    │ v0.1.28-alpha-1 │
│ white-gibbon-3  │ https://white-gibbon-3.anycloudapp.com  │ gcp-us        │ 1    │ v0.1.28-alpha-1 │
└─────────────────┴─────────────────────────────────────────┴───────────────┴──────┴─────────────────┘

Deployment configurations used from ~/.anycloud/deploy.json

┌───────────────┬────────────────┬────────────┐
│ Deploy Config │ Cloud Provider │ Region     │
├───────────────┼────────────────┼────────────┤
│ aws-us        │ AWS            │ us-west-1  │
│               │ AWS            │ us-east-1  │
│ gcp-us        │ GCP            │ us-west1-c │
└───────────────┴────────────────┴────────────┘

```

The second table will include VM type and whether it is using spot instances or not in the near future