### PR TITLE
add vmType to cloud config

### DIFF
--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -47,6 +47,7 @@ pub struct Config {
   credentials: Credentials,
   region: String,
   cloudProvider: String,
+  vmType: String,
 }
 
 #[allow(non_snake_case)]
@@ -223,12 +224,18 @@ pub async fn info() {
     };
     deploy.columns.insert(2, column);
 
+    let column = Column {
+      header: "VM Type".into(),
+      ..Column::default()
+    };
+    deploy.columns.insert(3, column);
+
     let cloud_configs = deploy_configs.get(&deploy_name.to_string()).unwrap();
     for (i, cloud_config) in cloud_configs.iter().enumerate() {
       if i == 0 {
-        data.push(vec![deploy_name, &cloud_config.cloudProvider, &cloud_config.region])
+        data.push(vec![deploy_name, &cloud_config.cloudProvider, &cloud_config.region, &cloud_config.vmType])
       } else {
-        data.push(vec![&"", &cloud_config.cloudProvider, &cloud_config.region])
+        data.push(vec![&"", &cloud_config.cloudProvider, &cloud_config.region, &cloud_config.vmType])
       };
     }
   }


### PR DESCRIPTION
```
┌────────────────┬────────────────────────────────────────┬───────────────┬──────┬─────────────────┐
│ App Id         │ Url                                    │ Deploy Config │ Size │ Version         │
├────────────────┼────────────────────────────────────────┼───────────────┼──────┼─────────────────┤
│ copper-gull-92 │ https://copper-gull-92.anycloudapp.com │ aws-us        │ 2    │ v0.1.28-alpha-4 │
│ aqua-mite-98   │ https://aqua-mite-98.anycloudapp.com   │ gcp-us        │ 1    │ v0.1.28-alpha-4 │
└────────────────┴────────────────────────────────────────┴───────────────┴──────┴─────────────────┘

Deployment configurations used from ~/.anycloud/deploy.json

┌───────────────┬────────────────┬────────────┬──────────┐
│ Deploy Config │ Cloud Provider │ Region     │ VM Type  │
├───────────────┼────────────────┼────────────┼──────────┤
│ aws-us        │ AWS            │ us-west-1  │ t3.micro │
│               │ AWS            │ us-east-1  │ t2.micro │
│ gcp-us        │ GCP            │ us-west1-c │ e2-micro │
└───────────────┴────────────────┴────────────┴──────────┘
```