### PR TITLE
use set instead of list

### DIFF
--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, from_str, json, Value};
 use spinner::SpinnerBuilder;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Display;
 use std::fs::{File, read};
@@ -191,10 +191,10 @@ pub async fn info() {
   };
   clusters.columns.insert(4, column);
 
-  let mut deploy_names = Vec::new();
+  let mut deploy_names = HashSet::new();
   let mut data: Vec<Vec<&dyn Display>> = vec![];
   for app in &mut apps {
-    deploy_names.push(&app.deployName);
+    deploy_names.insert(&app.deployName);
     data.push(vec![&app.id, &app.url, &app.deployName, &app.size, &app.version]);
   }
 


### PR DESCRIPTION
This was generating duplicated deployment configuration visualization
```
Deployment configurations used from ~/.anycloud/deploy.json

┌───────────────┬────────────────┬────────────┬──────────┐
│ Deploy Config │ Cloud Provider │ Region     │ VM Type  │
├───────────────┼────────────────┼────────────┼──────────┤
│ aws-us        │ AWS            │ us-west-1  │ t3.micro │
│               │ AWS            │ us-east-1  │ t2.micro │
│ gcp-us        │ GCP            │ us-west1-c │ e2-micro │
│ gcp-us        │ GCP            │ us-west1-c │ e2-micro │
└───────────────┴────────────────┴────────────┴──────────┘
```